### PR TITLE
ci: add npm publish workflow with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to publish.
+        type: choice
+        options:
+          - react-native-rag
+          - '@react-native-rag/executorch'
+          - '@react-native-rag/op-sqlite'
+        required: true
+      release-type:
+        description: Type of release to publish.
+        type: choice
+        options: [stable, nightly, beta, alpha, rc]
+        default: stable
+      version:
+        description: Explicit version in x.y.z format (leave empty to infer automatically).
+        type: string
+        required: false
+        default: ''
+      perform-git-operations:
+        description: Create and push the release commit + tag.
+        type: boolean
+        default: false
+      dry-run:
+        description: Dry run — no actual publish or git push.
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    concurrency:
+      group: publish-${{ inputs.package }}-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - name: Publish react-native-rag
+        if: ${{ inputs.package == 'react-native-rag' }}
+        uses: software-mansion/npm-package-publish@22b6e632b4310c5c061a047bccc99d0cea88d2bb
+        with:
+          package-name: 'react-native-rag'
+          package-json-path: 'package.json'
+          install-dependencies-command: 'yarn install --immutable'
+          release-type: ${{ inputs.release-type }}
+          version: ${{ inputs.version }}
+          perform-git-operations: ${{ inputs.perform-git-operations }}
+          dry-run: ${{ inputs.dry-run }}
+
+      - name: Publish @react-native-rag/executorch
+        if: ${{ inputs.package == '@react-native-rag/executorch' }}
+        uses: software-mansion/npm-package-publish@22b6e632b4310c5c061a047bccc99d0cea88d2bb
+        with:
+          package-name: '@react-native-rag/executorch'
+          package-json-path: 'packages/executorch/package.json'
+          install-dependencies-command: 'yarn install --immutable'
+          release-type: ${{ inputs.release-type }}
+          version: ${{ inputs.version }}
+          perform-git-operations: ${{ inputs.perform-git-operations }}
+          dry-run: ${{ inputs.dry-run }}
+
+      - name: Publish @react-native-rag/op-sqlite
+        if: ${{ inputs.package == '@react-native-rag/op-sqlite' }}
+        uses: software-mansion/npm-package-publish@22b6e632b4310c5c061a047bccc99d0cea88d2bb
+        with:
+          package-name: '@react-native-rag/op-sqlite'
+          package-json-path: 'packages/op-sqlite/package.json'
+          install-dependencies-command: 'yarn install --immutable'
+          release-type: ${{ inputs.release-type }}
+          version: ${{ inputs.version }}
+          perform-git-operations: ${{ inputs.perform-git-operations }}
+          dry-run: ${{ inputs.dry-run }}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "homepage": "https://github.com/software-mansion-labs/react-native-rag#readme",
   "publishConfig": {
+    "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {

--- a/packages/executorch/package.json
+++ b/packages/executorch/package.json
@@ -7,6 +7,15 @@
   },
   "license": "MIT",
   "description": "React Native ExecuTorch wrapper for React Native RAG",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion-labs/react-native-rag.git",
+    "directory": "packages/executorch"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "peerDependencies": {
     "react-native-executorch": "^0.8.0",
     "react-native-rag": "^0.8.0"

--- a/packages/op-sqlite/package.json
+++ b/packages/op-sqlite/package.json
@@ -7,6 +7,15 @@
   },
   "license": "MIT",
   "description": "OP-SQLite wrapper for React Native RAG",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion-labs/react-native-rag.git",
+    "directory": "packages/op-sqlite"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "peerDependencies": {
     "@op-engineering/op-sqlite": "^15.2.7",
     "react-native-rag": "^0.8.0"


### PR DESCRIPTION
## Summary

Adds a manual-trigger `publish.yml` workflow built on top of [`software-mansion/npm-package-publish`](https://github.com/software-mansion/npm-package-publish), and the package.json fields it needs to produce a valid provenance attestation.

### What changed

- New `.github/workflows/publish.yml` — `workflow_dispatch` only. Inputs: package (dropdown of the three published packages), release-type (`stable` / `nightly` / `beta` / `alpha` / `rc`), explicit version, `perform-git-operations`, and `dry-run` (defaults to `true`).
- `repository` (with `directory` subpath) and `publishConfig.access: public` added to both scoped sub-packages — required for provenance on monorepo packages and for npm to allow publishing scoped packages publicly.
- `publishConfig.access: public` added to the root for consistency.

### Before merging

1. Configure a **Trusted Publisher** on npm for each of the three packages — pointing at this repo + `publish.yml`. The package settings must also use the 2FA mode that allows trusted publishing (the default "Require 2FA and disallow tokens" is fine — Trusted Publishing is not token-based).
2. First run should be done with `dry-run: true` to validate the OIDC handshake.

### Notes

- Each workflow run publishes a single package. For a coordinated release, run it three times. Only one of those runs should have `perform-git-operations: true` to avoid duplicate tag pushes.
- The action is pinned to a specific commit SHA, per its setup guide.