### PR TITLE
docs(op-sqlite): use real executorch types in README usage example

### DIFF
--- a/packages/op-sqlite/README.md
+++ b/packages/op-sqlite/README.md
@@ -37,14 +37,20 @@ To use `OPSQLiteVectorStore`, you need to instantiate it with an `Embeddings` im
 ```typescript
 import { useRAG } from 'react-native-rag';
 import { OPSQLiteVectorStore } from '@react-native-rag/op-sqlite';
-import { YourLLM, YourEmbeddings } from './your-implementations'; // Provide your own LLM and Embeddings
+import {
+  ExecuTorchEmbeddings,
+  ExecuTorchLLM,
+} from '@react-native-rag/executorch';
+import { models } from 'react-native-executorch';
 
 const App = () => {
   const { isReady, generate, addDocument } = useRAG({
-    llm: new YourLLM(),
+    llm: new ExecuTorchLLM(models.llm.lfm2_5_1_2b_instruct()),
     vectorStore: new OPSQLiteVectorStore({
       name: 'my-vector-db',
-      embeddings: new YourEmbeddings(),
+      embeddings: new ExecuTorchEmbeddings(
+        models.text_embedding.all_minilm_l6_v2()
+      ),
     }),
   });
 


### PR DESCRIPTION
## Summary

Replace the placeholder \`YourLLM\` / \`YourEmbeddings\` imports in [packages/op-sqlite/README.md](packages/op-sqlite/README.md) with the actual \`ExecuTorchLLM\` / \`ExecuTorchEmbeddings\` classes from \`@react-native-rag/executorch\`, wired through the rne 0.9.0 \`models.*\` accessor. Mirrors the example already shown in the root README and \`packages/executorch/README.md\` so the snippet is copy-pasteable.

### Why this is on a separate PR

\`@react-native-rag/op-sqlite@0.9.0\` failed to publish from the v0.9.0 tag due to a Sigstore/Rekor transparency-log conflict (the first publish attempt registered the tarball signature in Rekor before failing on the npm side, and Rekor refuses duplicate entries on retry). The other two packages published fine. This README touch changes the op-sqlite tarball bytes so Rekor will accept a fresh entry. Once merged, \`v0.9.0\` gets moved to the new commit and the workflow re-run for op-sqlite only.