### PR TITLE
chore(op-sqlite): add files allowlist to package.json

### DIFF
--- a/packages/op-sqlite/package.json
+++ b/packages/op-sqlite/package.json
@@ -2,6 +2,10 @@
   "name": "@react-native-rag/op-sqlite",
   "version": "0.9.0",
   "main": "src/index.ts",
+  "files": [
+    "src",
+    "README.md"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary

Add a \`files\` allowlist to [packages/op-sqlite/package.json](packages/op-sqlite/package.json) restricting the published tarball to \`src/\` and \`README.md\`. Brings op-sqlite in line with how the root package controls its tarball contents and prevents accidental dev/build leakage.

### Why now

\`@react-native-rag/op-sqlite@0.9.0\` is stuck on a Sigstore/Rekor transparency-log conflict from the first failed publish attempt against the \`v0.9.0\` tag. The Rekor entry is immutable, so a republish from the same commit produces the same tarball hash → 409. This small content change is a real hygiene fix that also alters the tarball bytes enough for Rekor to accept a fresh entry.

### Publishing plan after merge

- Tag the merge commit as \`op-sqlite/v0.9.0\` (per-package namespaced tag; leaves \`v0.9.0\` pointing at \`7f064b0\` so the existing published \`react-native-rag@0.9.0\` and \`@react-native-rag/executorch@0.9.0\` provenance attestations stay consistent).
- Run the publish workflow from tag \`op-sqlite/v0.9.0\`, package \`@react-native-rag/op-sqlite\`, version \`0.9.0\`.